### PR TITLE
merge should overwrite existing properties

### DIFF
--- a/build/cloner.node.js
+++ b/build/cloner.node.js
@@ -173,7 +173,9 @@ var cloner = (function (O) {'use strict';
               }else{
 	            set(descriptors, key, descriptor);
               }
-            }
+            }else{
+	          set(descriptors, key, descriptor);
+	        }
           } else {
             if (deep && VALUE in descriptor) {
               deepValue(descriptor);

--- a/build/cloner.node.js
+++ b/build/cloner.node.js
@@ -170,6 +170,8 @@ var cloner = (function (O) {'use strict';
                     merge.call(deep, tvalue, value);
                   }
                 }
+              }else{
+	            set(descriptors, key, descriptor);
               }
             }
           } else {

--- a/src/cloner.js
+++ b/src/cloner.js
@@ -148,6 +148,8 @@ var cloner = (function (O) {'use strict';
                     merge.call(deep, tvalue, value);
                   }
                 }
+              }else{
+	            set(descriptors, key, descriptor);
               }
             }
           } else {

--- a/src/cloner.js
+++ b/src/cloner.js
@@ -151,6 +151,8 @@ var cloner = (function (O) {'use strict';
               }else{
 	            set(descriptors, key, descriptor);
               }
+            }else{
+	          set(descriptors, key, descriptor);
             }
           } else {
             if (deep && VALUE in descriptor) {

--- a/test/cloner.js
+++ b/test/cloner.js
@@ -44,7 +44,7 @@ wru.test([
       var a = {a: 1, b: 2};
       var b = cloner.shallow.merge({a: 3}, a);
       wru.assert('it did not have problems with already available properties',
-        b.a === 3 &&
+        b.a === 1 &&
         b.b === 2
       );
       var a = {a: 1, b: 2};
@@ -82,14 +82,24 @@ wru.test([
   }, {
     name: 'deep.merge',
     test: function () {
-      var a = {a: {a: 1}, b: {b: 2}};
+      var a = {a: {a: 1}, b: {b: 2}, c: 4};
       var b = cloner.deep.merge({a: {c: 3}}, a);
       wru.assert('it did merge deeply',
         a.a !== b.a &&
         a.b !== b.b &&
         b.a.a === 1 &&
         b.a.c === 3 &&
-        b.b.b === 2
+        b.b.b === 2 &&
+        b.c === 4
+      );
+      var b = cloner.deep.merge({a: {a: 0, c: 3}, b: {b: 1}, c: 2}, a);
+      wru.assert('it did merge over existing properties',
+        a.a !== b.a &&
+        a.b !== b.b &&
+        b.a.a === 1 &&
+        b.a.c === 3 &&
+        b.b.b === 2 &&
+        b.c === 4
       );
       a.f = a;
       var b = cloner.deep.merge({a: {c: 3}}, a);

--- a/test/cloner.js
+++ b/test/cloner.js
@@ -82,7 +82,7 @@ wru.test([
   }, {
     name: 'deep.merge',
     test: function () {
-      var a = {a: {a: 1}, b: {b: 2}, c: 4};
+      var a = {a: {a: 1, get e(){ return true; }}, b: {b: 2}, c: 4};
       var b = cloner.deep.merge({a: {c: 3}}, a);
       wru.assert('it did merge deeply',
         a.a !== b.a &&
@@ -92,14 +92,15 @@ wru.test([
         b.b.b === 2 &&
         b.c === 4
       );
-      var b = cloner.deep.merge({a: {a: 0, c: 3}, b: {b: 1}, c: 2}, a);
+      var b = cloner.deep.merge({a: {a: 0, get e(){ return false; }, c: 3}, b: {b: 1}, c: 2}, a);
       wru.assert('it did merge over existing properties',
         a.a !== b.a &&
         a.b !== b.b &&
         b.a.a === 1 &&
         b.a.c === 3 &&
         b.b.b === 2 &&
-        b.c === 4
+        b.c === 4 &&
+        b.a.e === true
       );
       a.f = a;
       var b = cloner.deep.merge({a: {c: 3}}, a);


### PR DESCRIPTION
When merging, the rightmost objects values should overwrite the leftmost object values, even if they already exist